### PR TITLE
修复若干问题

### DIFF
--- a/src/config/view.html
+++ b/src/config/view.html
@@ -43,6 +43,18 @@
                         <span class="q-switch__handle"></span>
                     </div>
                 </div>
+                <hr class="horizontal-dividing-line" id="send_to_input_divline" style="display: none" />
+                <div class="vertical-list-item" id="send_to_input_item" style="display: none">
+                    <div>
+                        <h2>表情发送到消息输入区</h2>
+                        <span class="secondary-text"
+                            >否则直接发送, 修改后重启生效</span
+                        >
+                    </div>
+                    <div class="q-switch" id="send_to_input">
+                        <span class="q-switch__handle"></span>
+                    </div>
+                </div>
                 <hr class="horizontal-dividing-line" />
                 <div class="vertical-list-item">
                     <div>

--- a/src/handler/handler.js
+++ b/src/handler/handler.js
@@ -7,7 +7,7 @@ const { log } = require('../logger.js');
 const getAllRemoteStickers = require('../remote/remote.js');
 const downloadRemoteStickers = require('../remote/download.js');
 
-const stickerFileRegExp = new RegExp(/.+\.(png|jpe?g|gif)/g);
+const stickerFileRegExp = new RegExp(/.*\.(png|jpe?g|gif)$/);
 function isValidStickerFile(value) {
     return stickerFileRegExp.test(value);
 }

--- a/src/main.js
+++ b/src/main.js
@@ -6,6 +6,7 @@ const path = require('path');
 var defaultConfig = {
     sticker_together: false,
     enable_remote: false,
+    send_to_input: false,
     sticker_path: '',
 };
 

--- a/src/renderer/config/config.js
+++ b/src/renderer/config/config.js
@@ -32,6 +32,11 @@ async function addConfigContent(view) {
         e.setAttribute('fill', idDarkMode ? '#ffffff' : '#000000');
     });
 
+    if (navigator.userAgentData.platform == 'Windows') {
+        view.querySelector('#send_to_input_divline').style.display = '';
+        view.querySelector('#send_to_input_item').style.display = '';
+    }
+
     log('Added config view');
 }
 
@@ -115,6 +120,7 @@ async function listenConfigContent(view) {
 
     listenSwitch('sticker_together');
     listenSwitch('enable_remote');
+    listenSwitch('send_to_input');
 
     listenChange(
         'sticker_path',

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -11,7 +11,7 @@ const { initStickerMenu } = await import(
 function onLoad() {
     var getpanelInterval = setInterval(() => {
         var panel = document.querySelector(
-            '#app > div.container > div.tab-container > div > div.aio > div.group-panel.need-token-updated > div.group-chat > div.chat-input-area.no-copy > div.expression-panel > div > div',
+            '#app > div.container   div.group-panel > div.group-chat > div.chat-input-area > div.expression,div.expression-panel > div > div.sticker-panel',
         );
         if (!panel) return;
 

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -10,9 +10,7 @@ const { initStickerMenu } = await import(
 // 页面加载完成时触发
 function onLoad() {
     var getpanelInterval = setInterval(() => {
-        var panel = document.querySelector(
-            '#app > div.container   div.group-panel > div.group-chat > div.chat-input-area > div.expression,div.expression-panel > div > div.sticker-panel',
-        );
+        var panel = document.querySelector('div.sticker-panel');
         if (!panel) return;
 
         initStickerMenu(panel);

--- a/src/renderer/sticker/addMenu.js
+++ b/src/renderer/sticker/addMenu.js
@@ -6,7 +6,7 @@
  */
 function setPageShow(id, show, pageWrapper) {
     pageWrapper.querySelector('#page-' + id).style.display = show
-        ? 'block'
+        ? ''
         : 'none';
 }
 
@@ -17,15 +17,13 @@ function setPageShow(id, show, pageWrapper) {
  * @param {string} icon 图标
  * @param {Element} page 页面
  * @param {string} id tab id
- * @returns {HTMLElement} page元素
+ * @returns {HTMLElement} page 元素
  */
+var nowTabId = -1;    // 记录当前 tab id，-1 表示 QQ 原有 tab
 export function addMenu(panel, title, icon, page, id) {
     const iconElement = document.createElement('div');
     iconElement.innerHTML = `<i class="q-icon" title="${title}" is-bold="true"style="color:var(--icon_primary); height:24px;">${icon}</i>`;
-    iconElement.classList.add(
-        'tabs-container-item',
-        'stickerpp-container-item',
-    );
+    iconElement.classList.add('stickerpp-container-item');
     iconElement.id = id;
 
     // Page
@@ -42,23 +40,45 @@ export function addMenu(panel, title, icon, page, id) {
     const tabElement = panel.querySelector('div.tabs.sticker-panel__bar > div');
     tabElement.appendChild(iconElement);
 
+    // 切换到本 tab
     iconElement.addEventListener('click', () => {
-        // 切换到本tab
+        // 切换出其他 tab
         panel
             .querySelectorAll('.tabs-container-item-active')
-            .forEach((e) => e.classList.remove('tabs-container-item-active'));
+            .forEach((e) => {
+                e.classList.remove('tabs-container-item-active');
+                const icon = e.querySelector('i');
+                icon.style.cssText = icon.style.cssText.replace('var(--on_brand_secondary)', 'var(--icon_primary)');
+            });
+        panel
+            .querySelectorAll('.stickerpp-container-item-active')
+            .forEach((e) => {
+                e.classList.remove('stickerpp-container-item-active');
+            });
         panel
             .querySelectorAll('div.sticker-panel__pages > div')
             .forEach((e) => (e.style.display = 'none'));
+        // 切换到本 tab
+        iconElement.classList.add('stickerpp-container-item-active');
         setPageShow(id, true, pageWrapperElement);
+        // 更新 tab id
+        nowTabId = id;
     });
 
-    document.querySelectorAll('.tabs-container-item').forEach((e) =>
+    // 切换到其他 tab（QQ 原有 tab）
+    document.querySelectorAll('.tabs-container-item').forEach((e, eid) =>
         e.addEventListener('click', () => {
-            if (e.id != id) {
-                // 切换到其他tab
-                iconElement.classList.remove('tabs-container-item-active');
+            if (iconElement.classList.contains('stickerpp-container-item-active')) {
+                // 切换出本 tab
+                iconElement.classList.remove('stickerpp-container-item-active');
                 setPageShow(id, false, pageWrapperElement);
+                // 切换到其他 tab
+                e.classList.add('tabs-container-item-active');
+                const icon = e.querySelector('i');
+                icon.style.cssText = icon.style.cssText.replace('var(--icon_primary)', 'var(--on_brand_secondary)');
+                pageWrapperElement.children[eid].style.display = '';
+                // 更新 tab id
+                nowTabId = -1;
             }
         }),
     );
@@ -68,11 +88,22 @@ export function addMenu(panel, title, icon, page, id) {
     // 修复打开插件添加的tab后关闭表情, 再打开无法使用的问题
     setInterval(() => {
         var shortcutsElement = document.querySelector(
-            '#app > div.container > div.tab-container > div > div.aio > div.group-panel.need-token-updated > div.group-chat > div.chat-input-area.no-copy > div.chat-func-bar.shortcuts > div:nth-child(1) > div:nth-child(1) > div',
+            '#app > div.container   div.group-panel > div.group-chat > div.chat-input-area > div.chat-func-bar.shortcuts > div:nth-child(1) > div:nth-child(1) > div',
         );
         if (!shortcutsElement) return;
         shortcutsElement.addEventListener('click', () => {
-            setPageShow(id, false, pageWrapperElement);
+            if (nowTabId == id) {
+                pageWrapperElement.style.visibility = 'hidden';
+                setTimeout(() => {
+                    panel
+                        .querySelectorAll('div.sticker-panel__pages > div')
+                        .forEach((e) => (e.style.display = 'none'));
+                    setPageShow(id, true, pageWrapperElement);
+                    pageWrapperElement.style.visibility = '';
+                }, 50);
+            } else {
+                setPageShow(id, false, pageWrapperElement);
+            }
         });
     }, 500);
 

--- a/src/renderer/sticker/addMenu.js
+++ b/src/renderer/sticker/addMenu.js
@@ -91,9 +91,7 @@ export function addMenu(panel, title, icon, page, id) {
 
     // 修复打开插件添加的tab后关闭表情, 再打开无法使用的问题
     setInterval(() => {
-        var shortcutsElement = document.querySelector(
-            '#app > div.container   div.group-panel > div.group-chat > div.chat-input-area > div.chat-func-bar.shortcuts > div:nth-child(1) > div:nth-child(1) > div',
-        );
+        var shortcutsElement = document.querySelector('div.icon-item[aria-label="表情"]');
         if (!shortcutsElement) return;
         shortcutsElement.addEventListener('click', () => {
             if (nowTabId === id) {

--- a/src/renderer/sticker/addMenu.js
+++ b/src/renderer/sticker/addMenu.js
@@ -17,7 +17,7 @@ function setPageShow(id, show, pageWrapper) {
  * @param {string} icon 图标
  * @param {Element} page 页面
  * @param {string} id tab id
- * @returns {HTMLElement} page 元素
+ * @returns {HTMLElement} page元素
  */
 var nowTabId = -1;    // 记录当前 tab id，-1 表示 QQ 原有 tab
 export function addMenu(panel, title, icon, page, id) {
@@ -75,8 +75,12 @@ export function addMenu(panel, title, icon, page, id) {
                 // 切换到其他 tab
                 e.classList.add('tabs-container-item-active');
                 const icon = e.querySelector('i');
-                icon.style.cssText = icon.style.cssText.replace('var(--icon_primary)', 'var(--on_brand_secondary)');
-                pageWrapperElement.children[eid].style.display = '';
+                if (icon) {
+                    icon.style.cssText = icon.style.cssText.replace('var(--icon_primary)', 'var(--on_brand_secondary)');
+                    if (pageWrapperElement.childNodes[eid].tagName == 'DIV') {
+                        pageWrapperElement.childNodes[eid].style.display = '';
+                    }
+                }
                 // 更新 tab id
                 nowTabId = -1;
             }
@@ -92,7 +96,7 @@ export function addMenu(panel, title, icon, page, id) {
         );
         if (!shortcutsElement) return;
         shortcutsElement.addEventListener('click', () => {
-            if (nowTabId == id) {
+            if (nowTabId === id) {
                 pageWrapperElement.style.visibility = 'hidden';
                 setTimeout(() => {
                     panel

--- a/src/renderer/sticker/panel.js
+++ b/src/renderer/sticker/panel.js
@@ -4,6 +4,18 @@ const { addMenu } = await import(
 );
 
 async function sendSticker(stickerPath) {
+    const peer = await LLAPI.getPeer();
+    const elements = [
+        {
+            type: 'image',
+            file: stickerPath,
+            asface: true,
+        },
+    ];
+    await LLAPI.sendMessage(peer, elements);
+}
+
+async function sendStickerToInput(stickerPath) {        // 仅限于 Windows 平台
     const message = {
         type: "pic",
         src: stickerPath
@@ -41,7 +53,9 @@ export async function addLocalStickerPanel(panel) {
     );
     page.querySelectorAll('#local-sticker-item').forEach((btn) => {
         const stickerPath = btn.dataset.src;
-        btn.addEventListener('click', () => {
+        btn.addEventListener('click', toinput ? () => {
+            sendStickerToInput(stickerPath);
+        } : () => {
             sendSticker(stickerPath);
         });
     });
@@ -51,7 +65,7 @@ export async function addLocalStickerPanel(panel) {
  * 添加远程表情面板
  * @param {Element} panel 表情面板
  */
-export async function addRemoteStickerPanel(panel) {
+export async function addRemoteStickerPanel(panel, toinput) {
     /**
      * @type {string[]}
      */
@@ -78,11 +92,10 @@ export async function addRemoteStickerPanel(panel) {
     );
     page.querySelectorAll('#remote-sticker-item').forEach((btn) => {
         const stickerPath = btn.dataset.src;
-        btn.addEventListener('click', async () => {
-            const localPath =
-                await stickerpp.downloadRemoteSticker(stickerPath);
-            console.log(localPath);
-            sendSticker(localPath);
+        btn.addEventListener('click', toinput ? () => {
+            sendStickerToInput(stickerPath);
+        } : () => {
+            sendSticker(stickerPath);
         });
     });
 }

--- a/src/renderer/sticker/panel.js
+++ b/src/renderer/sticker/panel.js
@@ -8,9 +8,7 @@ async function sendSticker(stickerPath) {
         type: "pic",
         src: stickerPath
     };
-    document.querySelector(
-        '#app > div.container   div.group-panel > div.group-chat > div.chat-input-area > div.chat-func-bar.shortcuts > div:nth-child(1) > div:nth-child(1) > div',
-    ).click();
+    document.querySelector('div.icon-item[aria-label="表情"]').click();
     LLAPI.add_editor(message);
 }
 

--- a/src/renderer/sticker/panel.js
+++ b/src/renderer/sticker/panel.js
@@ -4,15 +4,14 @@ const { addMenu } = await import(
 );
 
 async function sendSticker(stickerPath) {
-    const peer = await LLAPI.getPeer();
-    const elements = [
-        {
-            type: 'image',
-            file: stickerPath,
-            asface: true,
-        },
-    ];
-    await LLAPI.sendMessage(peer, elements);
+    const message = {
+        type: "pic",
+        src: stickerPath
+    };
+    document.querySelector(
+        '#app > div.container   div.group-panel > div.group-chat > div.chat-input-area > div.chat-func-bar.shortcuts > div:nth-child(1) > div:nth-child(1) > div',
+    ).click();
+    LLAPI.add_editor(message);
 }
 
 /**

--- a/src/renderer/sticker/sticker.js
+++ b/src/renderer/sticker/sticker.js
@@ -15,6 +15,6 @@ export async function initStickerMenu(panel) {
 
     const config = await stickerpp.getConfig();
 
-    addLocalStickerPanel(panel);
-    if (config.enable_remote) addRemoteStickerPanel(panel);
+    addLocalStickerPanel(panel, config.send_to_input);
+    if (config.enable_remote) addRemoteStickerPanel(panel, config.send_to_input);
 }

--- a/src/sticker.css
+++ b/src/sticker.css
@@ -15,6 +15,15 @@
     color: var(--brand_standard);
 }
 
+.stickerpp-container-item-active, .stickerpp-container-item-active:active, .stickerpp-container-item-active:hover {
+    background-color: var(--global-brand_standard);
+}
+
+.stickerpp-container-item-active {
+    --global-brand_standard: var(--brand_standard);
+    color: var(--brand_standard);
+}
+
 .stickerpp-container {
     height: 100%;
     position: relative;
@@ -50,6 +59,14 @@
     -webkit-user-select: none;
     -moz-user-select: none;
     user-select: none;
+    width: 58px;
+    height: 58px;
+}
+
+.stickerpp-image:hover {
+    cursor: pointer;
+    transform: scale(1.1);
+    transform-origin: center center;
 }
 
 .stickerpp-image .image-content {


### PR DESCRIPTION
大致修复了以下问题：

1. 表情面板的选择器不适用于 Windows、Linux，修改后可用。
2. 修正检验本地图片文件名的正则表达式。
3. 切换到 Sticker++ 添加的 tab 时，tab 的图标和背景颜色应该相对应地切换。
4. 重新打开表情面板应该处于上一次关闭时的 tab。
5. 点击表情应该追加到输入框，而非直接发送。（QQ 自带的表情就是追加到输入框）
6. 鼠标移动到表情上时表情应该放大。